### PR TITLE
Fix CVE-2022-24765 safe.directory issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,9 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: mirror-repository
       uses: spyoungtech/mirror-action@v0.5.0
       with:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ For example, this project uses the following workflow to mirror from GitHub to G
 on: [push]
   ...
       steps:
-        - uses: actions/checkout@v1
+        - uses: actions/checkout@v3
+          with:
+            fetch-depth: 0
         - uses: yesolutions/mirror-action@master
           with:
             REMOTE: 'https://gitlab.com/spyoungtech/mirror-action.git'
@@ -40,7 +42,9 @@ Pretty much the same, but using `GIT_SSH_PRIVATE_KEY` and `GIT_SSH_KNOWN_HOSTS`
 
 ```yaml
       steps:
-        - uses: actions/checkout@v1
+        - uses: actions/checkout@v3
+          with:
+            fetch-depth: 0
         - uses: yesolutions/mirror-action@master
           with:
             REMOTE: 'ssh://git@gitlab.com/spyoungtech/mirror-action.git'
@@ -58,7 +62,9 @@ you can do so by using the `GIT_SSH_NO_VERIFY_HOST` input option. e.g.
 
 ```yaml
       steps:
-        - uses: actions/checkout@v1
+        - uses: actions/checkout@v3
+          with:
+            fetch-depth: 0
         - uses: yesolutions/mirror-action@master
           with:
             REMOTE: git@gitlab.com/spyoungtech/mirror-action.git

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,7 @@ GIT_SSH_NO_VERIFY_HOST=${INPUT_GIT_SSH_NO_VERIFY_HOST}
 GIT_SSH_KNOWN_HOSTS=${INPUT_GIT_SSH_KNOWN_HOSTS}
 HAS_CHECKED_OUT="$(git rev-parse --is-inside-work-tree 2>/dev/null || /bin/true)"
 
+git config --global --add safe.directory /github/workspace
 
 if [[ "${HAS_CHECKED_OUT}" != "true" ]]; then
     echo "WARNING: repo not checked out; attempting checkout" > /dev/stderr

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,8 @@ if [[ "${DEBUG}" -eq "true" ]]; then
     set -x
 fi
 
+git config --global --add safe.directory /github/workspace
+
 GIT_USERNAME=${INPUT_GIT_USERNAME:-${GIT_USERNAME:-"git"}}
 REMOTE=${INPUT_REMOTE:-"$*"}
 REMOTE_NAME=${INPUT_REMOTE_NAME:-"mirror"}
@@ -13,9 +15,7 @@ GIT_SSH_PUBLIC_KEY=${INPUT_GIT_SSH_PUBLIC_KEY}
 GIT_PUSH_ARGS=${INPUT_GIT_PUSH_ARGS:-"--tags --force --prune"}
 GIT_SSH_NO_VERIFY_HOST=${INPUT_GIT_SSH_NO_VERIFY_HOST}
 GIT_SSH_KNOWN_HOSTS=${INPUT_GIT_SSH_KNOWN_HOSTS}
-HAS_CHECKED_OUT="$(git rev-parse --is-inside-work-tree 2>/dev/null)"
-
-git config --global --add safe.directory /github/workspace
+HAS_CHECKED_OUT="$(git rev-parse --is-inside-work-tree 2>/dev/null || /bin/true)"
 
 if [[ "${HAS_CHECKED_OUT}" != "true" ]]; then
     echo "WARNING: repo not checked out; attempting checkout" > /dev/stderr

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,7 @@ if [[ "${HAS_CHECKED_OUT}" != "true" ]]; then
     echo "WARNING: this may result in missing commits in the remote mirror" > /dev/stderr
     echo "WARNING: this behavior is deprecated and will be removed in a future release" > /dev/stderr
     echo "WARNING: to remove this warning add the following to your yml job steps:" > /dev/stderr
-    echo " - uses: actions/checkout@v1" > /dev/stderr
+    echo " - uses: actions/checkout@v3" > /dev/stderr
     if [[ "${SRC_REPO}" -eq "" ]]; then
         echo "WARNING: SRC_REPO env variable not defined" > /dev/stderr
         SRC_REPO="https://github.com/${GITHUB_REPOSITORY}.git" > /dev/stderr

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ GIT_SSH_PUBLIC_KEY=${INPUT_GIT_SSH_PUBLIC_KEY}
 GIT_PUSH_ARGS=${INPUT_GIT_PUSH_ARGS:-"--tags --force --prune"}
 GIT_SSH_NO_VERIFY_HOST=${INPUT_GIT_SSH_NO_VERIFY_HOST}
 GIT_SSH_KNOWN_HOSTS=${INPUT_GIT_SSH_KNOWN_HOSTS}
-HAS_CHECKED_OUT="$(git rev-parse --is-inside-work-tree 2>/dev/null || /bin/true)"
+HAS_CHECKED_OUT="$(git rev-parse --is-inside-work-tree 2>/dev/null)"
 
 git config --global --add safe.directory /github/workspace
 


### PR DESCRIPTION
This fixes issue relating to [CVE-2022-24765](https://github.blog/2022-04-12-git-security-vulnerability-announced/) where checkouts fail with the following error

```
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```

Relating issues are https://github.com/actions/checkout/issues/760 and https://github.com/actions/checkout/issues/766.

This has been verified to work in our CI pipelines and the `README` has been updated accordingly.