### PR TITLE
Draft: Add GITHUB_REF as a configurable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Be sure to set the `GIT_PASSWORD` secret in your repo secrets settings.
 **NOTE:** by default, all branches are pushed. If you want to avoid
 this behavior, set `PUSH_ALL_REFS: "false"`. Set `GITHUB_REF` to the
 target branch if you want to use something specific. Since PRs and
-branches populate [`GITHUB_REF` differently](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context), using 
-`GITHUB_REF: ${{ github.head_ref || github.ref_name }}` would be the 
+branches populate [`GITHUB_REF` differently](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context), using
+`GITHUB_REF: ${{ github.head_ref || github.ref_name }}` would be the
 easiest way to target the right branch in and out of PRs.
 
 You can further customize the push behavior with the `GIT_PUSH_ARGS` parameter.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ Be sure to set the `GIT_PASSWORD` secret in your repo secrets settings.
 
 
 **NOTE:** by default, all branches are pushed. If you want to avoid
-this behavior, set `PUSH_ALL_REFS: "false"`
+this behavior, set `PUSH_ALL_REFS: "false"`. Set `GITHUB_REF` to the
+target branch if you want to use something specific. Since PRs and
+branches populate [`GITHUB_REF` differently](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context), using 
+`GITHUB_REF: ${{ github.head_ref || github.ref_name }}` would be the 
+easiest way to target the right branch in and out of PRs.
 
 You can further customize the push behavior with the `GIT_PUSH_ARGS` parameter.
 By default, this is set to `--tags --force --prune`

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,10 @@ inputs:
     description: "The arugments to use when pushing the repository"
     default: '--tags --force --prune'
     required: false
+  GITHUB_REF:
+    description: "The branch name to push to when not pushing all refs"
+    default: ${{ github.ref }}
+    required: false
   DEBUG:
     description: 'set to "true" to enable debug mode'
     default: "false"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,7 @@ GIT_SSH_PUBLIC_KEY=${INPUT_GIT_SSH_PUBLIC_KEY}
 GIT_PUSH_ARGS=${INPUT_GIT_PUSH_ARGS:-"--tags --force --prune"}
 GIT_SSH_NO_VERIFY_HOST=${INPUT_GIT_SSH_NO_VERIFY_HOST}
 GIT_SSH_KNOWN_HOSTS=${INPUT_GIT_SSH_KNOWN_HOSTS}
+GITHUB_REF=${GITHUB_REF}
 HAS_CHECKED_OUT="$(git rev-parse --is-inside-work-tree 2>/dev/null || /bin/true)"
 
 if [[ "${HAS_CHECKED_OUT}" != "true" ]]; then


### PR DESCRIPTION
Per [review comment](https://github.com/yesolutions/mirror-action/pull/16#pullrequestreview-1271584492) or #16, this adds configuration of `GITHUB_REF` as an option to push to a specific branch name during an action.

I was not confident how I could go about testing this, but I am sure some review will ensure this functions as intended.